### PR TITLE
Disable PermitTunnel and AllowTcpForwarding in sshd_config

### DIFF
--- a/roles/duo_security/tasks/main.yml
+++ b/roles/duo_security/tasks/main.yml
@@ -15,3 +15,15 @@
   lineinfile: dest=/etc/ssh/sshd_config regexp=^ForceCommand line="ForceCommand /usr/sbin/login_duo"
   notify:
   - restart sshd
+
+- name: Disable PermitTunnel and AllowTcpForwarding
+  lineinfile:
+    dest=/etc/ssh/sshd_config
+    state=present
+    regexp=^{{ item.key }}
+    line="{{ item.key }} {{ item.value }}"
+    insertafter=EOF
+  with_items:
+    - { key: 'PermitTunnel', value: 'no' }
+    - { key: 'AllowTcpForwarding', value: 'no' }
+  notify: restart sshd


### PR DESCRIPTION
The problem is that you can bypass two-factor authentication on certain operations when using ForceCommand to prompt the user to enter their OTP after successful initial auth via password/key/GSSAPI. ForceCommand doesn't prevent port forwarding from taking place after initial authentication, which means a user who has gotten access to a machine over brute-force or another unauthorized method can get access to ports which are firewalled or listening only on a loopback interface.

Here's how to reproduce the issue:
1. Have a machine with two-factor enabled using ForceCommand to prompt the user for their second form of auth.
2. Have a service listening on a TCP socket which is not available to the 'outside world'
3. ssh -L 8080:localhost:8080 me@mymachine.com (assuming the service is listening on 127.0.0.1:8080)
4. Log into the machine via SSH key or password, but do not enter your OTP
5. Notice that you can access the service on your local machine on port 8080 without completing two-factor authentication

Disabling these two options eliminates the possiblity of bypassing the second form of auth.
